### PR TITLE
Typo when handling exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class XBlockInstall(_install):
                         self.announce('Compiling translation at %s' % po_path)
                         subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
         except Exception as ex:
-            self.announce('Translations compilation failed: %s', ex.message)
+            self.announce('Translations compilation failed: %s' % ex.message)
 
 
 def package_data(pkg, root_list):


### PR DESCRIPTION
The method announce (defined at https://github.com/python/cpython/blob/2.7/Lib/distutils/cmd.py) takes 2 arguments, an string and a error level; so its clear this is a typo and instead of a "," there should be a "%" to interpolate the string