### PR TITLE
Python3 compatibility:: Fixes json.load error 

### DIFF
--- a/recommender/recommender.py
+++ b/recommender/recommender.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import codecs
 import hashlib
-import json
+import simplejson as json
 import lxml.etree as etree
 import pkg_resources
 import re

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-webob
+bleach==2.1.4
+boto
 fs
 mako
-boto
-bleach==2.1.4
 pycodestyle
+simplejson
+webob

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='recommender-xblock',
-    version='1.4.4',
+    version='1.4.5',
     description='recommender XBlock',   # TODO: write a better description.
     long_description=README,
     author='edX',


### PR DESCRIPTION
Following Tests Fail with the error "TypeError: the JSON object must be str, not 'bytes'"
TestRecommenderFileUploading.test_import_resources_wrong_format_1
TestRecommenderFileUploading.test_import_resources_2

python3 json is unable to load bytes type data. Error occures on following line.
https://github.com/edx/RecommenderXBlock/blob/master/recommender/recommender.py#L873

Arranged the requirements in requirents file. 