### PR TITLE
chore: Change the requirements upgrading PR reviewer team to CE

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -52,4 +52,4 @@ jobs:
           --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
           --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
           --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-          --user-reviewers="" --team-reviewers="" --delete-old-pull-requests
+          --user-reviewers="" --team-reviewers="community-engineering" --delete-old-pull-requests


### PR DESCRIPTION
@sarina I'm changing this team reviewer setting to avoid OpsGenie alerts - and this repo is owned by CE.